### PR TITLE
Remove Nodesource bash script from execution path 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian
+
+RUN apt update && apt install -y curl
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
+
+# NOTE: We are only installing chromium to get its dependencies
+RUN apt install -y chromium
+
+ADD index.js .
+ADD package.json .
+
+RUN npm install
+
+ENTRYPOINT ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian
 
-RUN apt update && apt install -y curl
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
-RUN apt-get install -y nodejs
+RUN apt update && apt install -y curl gpg
+RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg
+RUN echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x bullseye main' > /etc/apt/sources.list.d/nodesource.list
+RUN apt update && apt install -y nodejs
 
 # Install the below as they are needed by the chromium bundled with Puppeteer
 RUN apt install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,59 @@ RUN apt update && apt install -y curl
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs
 
-# NOTE: We are only installing chromium to get its dependencies
-RUN apt install -y chromium
+# Install the below as they are needed by the chromium bundled with Puppeteer
+RUN apt install -y \
+ libasound2 \
+ libatk-bridge2.0-0 \
+ libatk1.0-0 \
+ libatomic1 \
+ libatspi2.0-0 \
+ libc6 \
+ libcairo2 \
+ libcups2 \
+ libdbus-1-3 \
+ libdrm2 \ 
+ libevent-2.1-7 \
+ libexpat1 \
+ libflac8 \
+ libfontconfig1 \
+ libfreetype6 \
+ libgbm1 \
+ libgcc-s1 \
+ libglib2.0-0 \
+ libjpeg62-turbo \
+ libjsoncpp24 \
+ liblcms2-2 \
+ libminizip1 \
+ libnspr4 \
+ libnss3 \
+ libopenjp2-7 \
+ libopus0 \
+ libpango-1.0-0 \
+ libpng16-16 \
+ libpulse0 \
+ libre2-9 \
+ libsnappy1v5 \
+ libstdc++6 \
+ libwebp6 \
+ libwebpdemux2 \
+ libwebpmux3 \
+ libx11-6 \
+ libxcb1 \
+ libxcomposite1 \
+ libxdamage1 \
+ libxext6 \
+ libxfixes3 \
+ libxkbcommon0 \
+ libxml2 \
+ libxrandr2 \
+ libxslt1.1 \
+ libx11-xcb1 \
+ libxcb-dri3-0 \
+ libpangocairo-1.0-0 \
+ libgtk-3-0 \
+ zlib1g
+
 
 ADD index.js .
 ADD package.json .

--- a/README.md
+++ b/README.md
@@ -82,10 +82,9 @@ To build the docker image execute:
 
 To run the Docker image created above, execute:
 
-    docker run -e DISABLE_CHROME_SANDBOX=true -v /home/usre/code/blofetcha/docker-archive:/archive blofetcha
+    docker run -e DISABLE_CHROME_SANDBOX=true -v /home/user/code/blofetcha/docker-archive:/archive blofetcha
 
 NOTE: The mounted "docker-archive" volume will contain the archived Javascript files
-NOTE2: Currently the files are output as having `root:root` permissions and need to be changed after
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ This will run the app in archive-only mode and exit, creating gzipped bundles as
 
 Where `1655340486` is the timestamp, and `4.15.10` the site version.
 
+## Docker
+
+To build the docker image execute:
+
+    docker build . -t blofetcha
+
+To run the Docker image created above, execute:
+
+    docker run -e DISABLE_CHROME_SANDBOX=true -v /home/usre/code/blofetcha/docker-archive:/archive blofetcha
+
+NOTE: The mounted "docker-archive" volume will contain the archived Javascript files
+NOTE2: Currently the files are output as having `root:root` permissions and need to be changed after
+
 ## Usage
 
 Enter the following command to get usage information:

--- a/index.js
+++ b/index.js
@@ -248,14 +248,12 @@ async function getSiteVersion(page) {
 async function launch(url, selector, device) {
     'use strict';
 
-    var chrome_args = [];
+    const args = [];
     if (config.DISABLE_CHROME_SANDBOX){
-      chrome_args = ['--no-sandbox'];
+      args.push('--no-sandbox');
     }
 
-    const browser = await puppeteer.launch({
-       args: chrome_args,
-    }).catch(console.error);
+    const browser = await puppeteer.launch({args});
     const page = await browser.newPage();
 
     page

--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ const config = {
     COMPRESS: !process.env.NOCOMPRESS,
     MOBILE_DEVICE: process.env.MOBILE_DEVICE || 'iPhone 8 Plus',
     ARCHIVE_PATH: process.env.ARCHIVE_PATH || path.join(cwd, 'archive'),
+    DISABLE_CHROME_SANDBOX: process.env.DISABLE_CHROME_SANDBOX || false,
 
     sites: {
         'mega.nz': {
@@ -247,7 +248,14 @@ async function getSiteVersion(page) {
 async function launch(url, selector, device) {
     'use strict';
 
-    const browser = await puppeteer.launch();
+    var chrome_args = [];
+    if (config.DISABLE_CHROME_SANDBOX){
+      chrome_args = ['--no-sandbox'];
+    }
+
+    const browser = await puppeteer.launch({
+       args: chrome_args,
+    }).catch(console.error);
     const page = await browser.newPage();
 
     page


### PR DESCRIPTION
Instead of using the Nodesource bash script, get the GPG key and add the repository configuration to our container directly.